### PR TITLE
Update manifest's name field

### DIFF
--- a/pkg/manifest.yml
+++ b/pkg/manifest.yml
@@ -1,6 +1,6 @@
 version: v0.1.0
 node_version: v3.0.0
-name: python-mock-server
+name: mock-avs
 upgrade: recommended
 hardware_requirements:
   min_cpu_cores: 2


### PR DESCRIPTION
We should use the `name` field from the `manifest.yml` for the instance id, instead of the repository name. This change starts with updating the manifest file.